### PR TITLE
Update operator.adoc : Redirection issue at clilck of "here" link text

### DIFF
--- a/modules/getting-started/pages/operator.adoc
+++ b/modules/getting-started/pages/operator.adoc
@@ -15,7 +15,7 @@ helm repo add kaap https://datastax.github.io/kaap
 helm repo update
 ----
 
-. The KAAP Operator Helm chart is available for download (https://github.com/datastax/kaap/releases/latest)[here].
+. The KAAP Operator Helm chart is available for download https://github.com/datastax/kaap/releases/latest[here].
 . Install the KAAP operator Helm chart:
 +
 [source,helm]


### PR DESCRIPTION
URL was wrapped in parenthesis which was not required. Wrapping in parenthesis was causing 404 error on the page as the redirecting URL was getting tempered (suffixed by ')')