### PR TITLE
Fix broken link in operator.adoc

### DIFF
--- a/modules/getting-started/pages/operator.adoc
+++ b/modules/getting-started/pages/operator.adoc
@@ -15,7 +15,7 @@ helm repo add kaap https://datastax.github.io/kaap
 helm repo update
 ----
 
-. The KAAP Operator Helm chart is available for download (https://github.com/datastax/kaap/releases/latest)[here].
+. The KAAP Operator Helm chart is available for download https://github.com/datastax/kaap/releases/latest[here].
 . Install the KAAP operator Helm chart:
 +
 [source,shell]

--- a/modules/getting-started/pages/stack.adoc
+++ b/modules/getting-started/pages/stack.adoc
@@ -13,6 +13,7 @@ Check out the {pulsar-stack}.
 To install a PulsarCluster with the {pulsar-stack} included, do the following:
 
 . Install the DataStax Helm repository.
++
 [source,shell]
 ----
 helm repo add kaap https://datastax.github.io/kaap

--- a/modules/getting-started/pages/stack.adoc
+++ b/modules/getting-started/pages/stack.adoc
@@ -10,7 +10,7 @@ Check out the {pulsar-stack}.
 * Cert Manager
 * Keycloak
 
-To install a PulsarCluster with the {pulsar-stack} included:
+. Install a PulsarCluster with the {pulsar-stack} included:
 [tabs]
 ====
 Kubectl::

--- a/modules/getting-started/pages/stack.adoc
+++ b/modules/getting-started/pages/stack.adoc
@@ -29,8 +29,6 @@ Kubectl::
 --
 [source,shell]
 ----
-helm repo add kaap https://datastax.github.io/kaap
-helm repo update
 helm install pulsar kaap/kaap-stack --values helm/examples/dev-cluster/values.yaml
 ----
 --

--- a/modules/getting-started/pages/stack.adoc
+++ b/modules/getting-started/pages/stack.adoc
@@ -11,6 +11,16 @@ Check out the {pulsar-stack}.
 * Keycloak
 
 To install a PulsarCluster with the {pulsar-stack} included, do the following:
+
+. Install the DataStax Helm repository.
+[source,shell]
+----
+helm repo add kaap https://datastax.github.io/kaap
+helm repo update
+----
+
+. Install the {pulsar-stack} Helm chart.
++
 [tabs]
 ====
 Kubectl::

--- a/modules/getting-started/pages/stack.adoc
+++ b/modules/getting-started/pages/stack.adoc
@@ -11,7 +11,6 @@ Check out the {pulsar-stack}.
 * Keycloak
 
 To install a PulsarCluster with the {pulsar-stack} included:
-+
 [tabs]
 ====
 Kubectl::

--- a/modules/getting-started/pages/stack.adoc
+++ b/modules/getting-started/pages/stack.adoc
@@ -10,7 +10,7 @@ Check out the {pulsar-stack}.
 * Cert Manager
 * Keycloak
 
-. Install a PulsarCluster with the {pulsar-stack} included:
+To install a PulsarCluster with the {pulsar-stack} included, do the following:
 [tabs]
 ====
 Kubectl::


### PR DESCRIPTION
[Preview build](https://d5rxiv0do0q3v.cloudfront.net/mendonk-patch-1/kaap-operator/0.2.0/getting-started/operator.html)
Link syntax
`(https://github.com/datastax/kaap/releases/latest)[here]` -> `https://github.com/datastax/kaap/releases/latest[here]`

Also a visible passthrough `+` and syntax adjustment